### PR TITLE
Did vc demo bugfix

### DIFF
--- a/algo/firebase/front/src/components/102_taxVCListDetail/102_taxVCListDetailMain.tsx
+++ b/algo/firebase/front/src/components/102_taxVCListDetail/102_taxVCListDetailMain.tsx
@@ -12,6 +12,7 @@ import { TaxInquiry } from "../common/Forms";
 import Header from "../common/Header";
 import Loading from "../common/Loading";
 import { issuerPw } from "@/lib/algo/account/accounts";
+import Container from "../common/Container";
 
 
 const TaxVCListDetailMain = () => {
@@ -74,13 +75,13 @@ const TaxVCListDetailMain = () => {
               </div>
             </section>
             <TaxInquiry input={input} />
-            <div className={"relative w-80 mx-auto"}>
+            <div className={"relative w-70 mx-auto"}>              
               {isRevoking
                 ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC取消中...</span>
                 : null
               }
             </div>
-            <div className="py-0 px-[53px]">
+            <div className="w-70 mx-auto py-0">
               <div className="pt-4 pb-2 flex justify-between">
                 <button
                   onClick={() => router.push("/91_accountVCList")}
@@ -97,7 +98,6 @@ const TaxVCListDetailMain = () => {
                   </button>
                 }
               </div>
-
             </div>
           </>}
         <Loading isLoading={isLoading} />

--- a/algo/firebase/front/src/components/102_taxVCListDetail/102_taxVCListDetailMain.tsx
+++ b/algo/firebase/front/src/components/102_taxVCListDetail/102_taxVCListDetailMain.tsx
@@ -13,6 +13,7 @@ import Header from "../common/Header";
 import Loading from "../common/Loading";
 import { issuerPw } from "@/lib/algo/account/accounts";
 import Container from "../common/Container";
+import { useErrorHandler } from "react-error-boundary";
 
 
 const TaxVCListDetailMain = () => {
@@ -25,39 +26,48 @@ const TaxVCListDetailMain = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isRevoking, setIsRevoking] = useState(false);
   const issuerDidAccountGlobal = useRecoilValue(issuerDidAccountState);
+  const errorHandler = useErrorHandler();
 
   dayjs.locale("ja");
 
   useEffect(() => {
-    (async () => {
-      setIsLoading(() => true);
-      const algod = getAlgod(chain);
-      const id = router.query.id;
-      const TaxVC = TaxVCListGlobal.find((v) => v.message.content.content.id === Number(id));
-      if (TaxVC) {
-        const revoke = await verifyVerifiableCredential(algod, TaxVC);
-        setVC(TaxVC);
-        setInput(TaxVC.message.content.content);
-        setRevokeStatus(revoke);
-      }
+    try {
+      (async () => {
+        setIsLoading(() => true);
+        const algod = getAlgod(chain);
+        const id = router.query.id;
+        const TaxVC = TaxVCListGlobal.find((v) => v.message.content.content.id === Number(id));
+        if (TaxVC) {
+          const revoke = await verifyVerifiableCredential(algod, TaxVC);
+          setVC(TaxVC);
+          setInput(TaxVC.message.content.content);
+          setRevokeStatus(revoke);
+        }
 
-      setIsLoading(() => false);
-    })();
+        setIsLoading(() => false);
+      })();
+    } catch (e) {
+      errorHandler(e)
+    }
   }, [TaxVCListGlobal, chain, router.query])
 
   const revoke = async () => {
-    setIsRevoking(() => true);
-    const algod = getAlgod(chain);
-    if (issuerDidAccountGlobal && vc) {
-      await revokeVerifiableCredential(
-        algod,
-        issuerDidAccountGlobal,
-        vc,
-        issuerPw
-      );
+    try {
+      setIsRevoking(() => true);
+      const algod = getAlgod(chain);
+      if (issuerDidAccountGlobal && vc) {
+        await revokeVerifiableCredential(
+          algod,
+          issuerDidAccountGlobal,
+          vc,
+          issuerPw
+        );
+      }
+      setIsRevoking(() => false);
+      router.push("/103_taxVCListDone");
+    } catch (e) {
+      errorHandler(e);
     }
-    setIsRevoking(() => false);
-    router.push("/103_taxVCListDone");
   }
 
   return (
@@ -75,7 +85,7 @@ const TaxVCListDetailMain = () => {
               </div>
             </section>
             <TaxInquiry input={input} />
-            <div className={"relative w-70 mx-auto"}>              
+            <div className={"relative w-70 mx-auto"}>
               {isRevoking
                 ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC取消中...</span>
                 : null

--- a/algo/firebase/front/src/components/113_subsidyVCListDone/113_subsidyVCListDoneMain.tsx
+++ b/algo/firebase/front/src/components/113_subsidyVCListDone/113_subsidyVCListDoneMain.tsx
@@ -1,0 +1,7 @@
+import VCRevokeDone from "../common/VCRevokeDone";
+
+const SubsidyVCListDoneMain = () => {
+    return <VCRevokeDone />
+};
+
+export default SubsidyVCListDoneMain;

--- a/algo/firebase/front/src/components/113_subsidyVCListDone/index.ts
+++ b/algo/firebase/front/src/components/113_subsidyVCListDone/index.ts
@@ -1,0 +1,3 @@
+import SubsidyVCListDoneMain from "./113_subsidyVCListDoneMain";
+
+export default SubsidyVCListDoneMain;

--- a/algo/firebase/front/src/components/15_residentListDetail/15_residentListDetailMain.tsx
+++ b/algo/firebase/front/src/components/15_residentListDetail/15_residentListDetailMain.tsx
@@ -132,7 +132,7 @@ const ResidentListDetailMain = () => {
       }
         <div className="py-0 px-[53px]">
           {selectDetail && <ResidentInquiry input={selectDetail.message.content} />}
-          <div className={"relative"}>
+          <div className={"w-70 mx-auto relative"}>          
             {isIssuing
               ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC発行中...</span>
               : null

--- a/algo/firebase/front/src/components/15_residentListDetail/15_residentListDetailMain.tsx
+++ b/algo/firebase/front/src/components/15_residentListDetail/15_residentListDetailMain.tsx
@@ -141,41 +141,39 @@ const ResidentListDetailMain = () => {
               : null
             }
           </div>
-          <Container>
-            <div className="w-full pt-4 pb-2 px-5 flex justify-between">
-              <button
-                onClick={() => router.push('/14_resident-list')}
-                className="input-form-button-white"
-              >
-                戻る
-              </button>
-              {
-                selectDetail && selectDetail.message.content.verifyStatus
-                  ? !selectDetail.message.content.approvalStatus &&
-                  <>
-                    <button
-                      onClick={reject}
-                      className="input-form-button-white"
-                    >
-                      却下
-                    </button>
-                    <button
-                      onClick={approve}
-                      className="input-form-button-blue"
-                    >
-                      承認
-                    </button>
-                  </>
-                  :
+          <div className="w-70 mx-auto pt-4 pb-2 flex justify-between">
+            <button
+              onClick={() => router.push('/14_resident-list')}
+              className="input-form-button-white"
+            >
+              戻る
+            </button>
+            {
+              selectDetail && selectDetail.message.content.verifyStatus
+                ? !selectDetail.message.content.approvalStatus &&
+                <>
                   <button
-                    onClick={verify}
+                    onClick={reject}
+                    className="input-form-button-white"
+                  >
+                    却下
+                  </button>
+                  <button
+                    onClick={approve}
                     className="input-form-button-blue"
                   >
-                    検証
+                    承認
                   </button>
-              }
-            </div>
-          </Container>
+                </>
+                :
+                <button
+                  onClick={verify}
+                  className="input-form-button-blue"
+                >
+                  検証
+                </button>
+            }
+          </div>
         </div>
       </main>
     </>

--- a/algo/firebase/front/src/components/15_residentListDetail/15_residentListDetailMain.tsx
+++ b/algo/firebase/front/src/components/15_residentListDetail/15_residentListDetailMain.tsx
@@ -123,16 +123,19 @@ const ResidentListDetailMain = () => {
 
         <section className={"flex flex-col items-center gap-1 w-72 mx-auto mb-2 pb-4 border-b"}>
           {selectDetail.message.content.verifyStatus
-            ? <p className={"relative text-sm leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
+            ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
             : <p className={"relative text-sm leading-relaxed"}><img src='/warning.svg' className={"absolute -translate-x-full pr-2"} /> 要検証</p>
           }
-          <p className={"text-sm text-color-gray-search leading-relaxed"}>{selectDetail.message.content.approvalStatus ? "承認済" : "未承認"}</p>
+          {selectDetail.message.content.approvalStatus
+            ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />承認済</p>
+            : <p className={"text-sm text-color-required leading-relaxed"}>未承認</p>
+          }
           <p className={"text-xs text-color-gray-search leading-relaxed"}>申請日 {dayjs(selectDetail.message.content.applicationDate).format("YY/MM/DD HH:mm")}</p>
         </section>
       }
         <div className="py-0 px-[53px]">
           {selectDetail && <ResidentInquiry input={selectDetail.message.content} />}
-          <div className={"w-70 mx-auto relative"}>          
+          <div className={"w-70 mx-auto relative"}>
             {isIssuing
               ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC発行中...</span>
               : null

--- a/algo/firebase/front/src/components/15_residentListDetail/15_residentListDetailMain.tsx
+++ b/algo/firebase/front/src/components/15_residentListDetail/15_residentListDetailMain.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from 'react';
 import { useErrorHandler } from 'react-error-boundary';
 import { ResidentVCRequestType } from '@/lib/types/mockApp';
 import { ResidentInquiry } from '../common/Forms';
+import Container from '../common/Container';
 
 const ResidentListDetailMain = () => {
   const router = useRouter();
@@ -137,39 +138,41 @@ const ResidentListDetailMain = () => {
               : null
             }
           </div>
-          <div className="pt-4 flex justify-between">
-            <button
-              onClick={() => router.push('/14_resident-list')}
-              className="input-form-button-white"
-            >
-              戻る
-            </button>
-            {
-              selectDetail && selectDetail.message.content.verifyStatus
-                ? !selectDetail.message.content.approvalStatus &&
-                <>
+          <Container>
+            <div className="w-full pt-4 pb-2 px-5 flex justify-between">
+              <button
+                onClick={() => router.push('/14_resident-list')}
+                className="input-form-button-white"
+              >
+                戻る
+              </button>
+              {
+                selectDetail && selectDetail.message.content.verifyStatus
+                  ? !selectDetail.message.content.approvalStatus &&
+                  <>
+                    <button
+                      onClick={reject}
+                      className="input-form-button-white"
+                    >
+                      却下
+                    </button>
+                    <button
+                      onClick={approve}
+                      className="input-form-button-blue"
+                    >
+                      承認
+                    </button>
+                  </>
+                  :
                   <button
-                    onClick={reject}
-                    className="input-form-button-white"
-                  >
-                    却下
-                  </button>
-                  <button
-                    onClick={approve}
+                    onClick={verify}
                     className="input-form-button-blue"
                   >
-                    承認
+                    検証
                   </button>
-                </>
-                :
-                <button
-                  onClick={verify}
-                  className="input-form-button-blue"
-                >
-                  検証
-                </button>
-            }
-          </div>
+              }
+            </div>
+          </Container>
         </div>
       </main>
     </>

--- a/algo/firebase/front/src/components/25_accountListDetail/25_accountListDetailMain.tsx
+++ b/algo/firebase/front/src/components/25_accountListDetail/25_accountListDetailMain.tsx
@@ -15,6 +15,7 @@ import { holderPw, issuerPw } from '@/lib/algo/account/accounts';
 import { useState } from 'react';
 import { useErrorHandler } from 'react-error-boundary';
 import { AccountInquiry } from '../common/Forms';
+import Container from '../common/Container';
 
 const AccountListDetailMain = () => {
   const router = useRouter();
@@ -132,39 +133,41 @@ const AccountListDetailMain = () => {
               : null
             }
           </div>
-          <div className="pt-4 pb-2 flex justify-between">
-            <button
-              onClick={() => router.push('/24_account-list')}
-              className="input-form-button-white"
-            >
-              戻る
-            </button>
-            {
-              selectDetail && selectDetail.message.content.verifyStatus
-                ? !selectDetail.message.content.approvalStatus &&
-                <>
+          <Container>
+            <div className="w-full pt-4 pb-2 px-5 flex justify-between">
+              <button
+                onClick={() => router.push('/24_account-list')}
+                className="input-form-button-white"
+              >
+                戻る
+              </button>
+              {
+                selectDetail && selectDetail.message.content.verifyStatus
+                  ? !selectDetail.message.content.approvalStatus &&
+                  <>
+                    <button
+                      onClick={reject}
+                      className="input-form-button-white"
+                    >
+                      却下
+                    </button>
+                    <button
+                      onClick={approve}
+                      className="input-form-button-blue"
+                    >
+                      承認
+                    </button>
+                  </>
+                  :
                   <button
-                    onClick={reject}
-                    className="input-form-button-white"
-                  >
-                    却下
-                  </button>
-                  <button
-                    onClick={approve}
+                    onClick={verify}
                     className="input-form-button-blue"
                   >
-                    承認
+                    検証
                   </button>
-                </>
-                :
-                <button
-                  onClick={verify}
-                  className="input-form-button-blue"
-                >
-                  検証
-                </button>
-            }
-          </div>
+              }
+            </div>
+          </Container>
         </div>
       </main>
     </>

--- a/algo/firebase/front/src/components/25_accountListDetail/25_accountListDetailMain.tsx
+++ b/algo/firebase/front/src/components/25_accountListDetail/25_accountListDetailMain.tsx
@@ -118,10 +118,13 @@ const AccountListDetailMain = () => {
         {selectDetail &&
           <section className={"flex flex-col items-center gap-1 w-72 mx-auto mb-2 pb-4 border-b"}>
             {selectDetail.message.content.verifyStatus
-              ? <p className={"relative text-sm leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
+              ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
               : <p className={"relative text-sm leading-relaxed"}><img src='/warning.svg' className={"absolute -translate-x-full pr-2"} /> 要検証</p>
             }
-            <p className={"text-sm text-color-gray-search leading-relaxed"}>{selectDetail.message.content.approvalStatus ? "承認済" : "未承認"}</p>
+            {selectDetail.message.content.approvalStatus
+              ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />承認済</p>
+              : <p className={"text-sm text-color-required leading-relaxed"}>未承認</p>
+            }
             <p className={"text-xs text-color-gray-search leading-relaxed"}>申請日 {dayjs(selectDetail.message.content.applicationDate).format("YY/MM/DD HH:mm")}</p>
           </section>
         }

--- a/algo/firebase/front/src/components/25_accountListDetail/25_accountListDetailMain.tsx
+++ b/algo/firebase/front/src/components/25_accountListDetail/25_accountListDetailMain.tsx
@@ -127,7 +127,7 @@ const AccountListDetailMain = () => {
         }
         <div className="py-0 px-[53px]">
           {selectDetail && <AccountInquiry input={selectDetail.message.content} />}
-          <div className={"relative"}>
+          <div className={"w-70 mx-auto relative"}>
             {isIssuing
               ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC発行中...</span>
               : null

--- a/algo/firebase/front/src/components/25_accountListDetail/25_accountListDetailMain.tsx
+++ b/algo/firebase/front/src/components/25_accountListDetail/25_accountListDetailMain.tsx
@@ -136,41 +136,39 @@ const AccountListDetailMain = () => {
               : null
             }
           </div>
-          <Container>
-            <div className="w-full pt-4 pb-2 px-5 flex justify-between">
-              <button
-                onClick={() => router.push('/24_account-list')}
-                className="input-form-button-white"
-              >
-                戻る
-              </button>
-              {
-                selectDetail && selectDetail.message.content.verifyStatus
-                  ? !selectDetail.message.content.approvalStatus &&
-                  <>
-                    <button
-                      onClick={reject}
-                      className="input-form-button-white"
-                    >
-                      却下
-                    </button>
-                    <button
-                      onClick={approve}
-                      className="input-form-button-blue"
-                    >
-                      承認
-                    </button>
-                  </>
-                  :
+          <div className="w-70 mx-auto pt-4 pb-2 flex justify-between">
+            <button
+              onClick={() => router.push('/24_account-list')}
+              className="input-form-button-white"
+            >
+              戻る
+            </button>
+            {
+              selectDetail && selectDetail.message.content.verifyStatus
+                ? !selectDetail.message.content.approvalStatus &&
+                <>
                   <button
-                    onClick={verify}
+                    onClick={reject}
+                    className="input-form-button-white"
+                  >
+                    却下
+                  </button>
+                  <button
+                    onClick={approve}
                     className="input-form-button-blue"
                   >
-                    検証
+                    承認
                   </button>
-              }
-            </div>
-          </Container>
+                </>
+                :
+                <button
+                  onClick={verify}
+                  className="input-form-button-blue"
+                >
+                  検証
+                </button>
+            }
+          </div>
         </div>
       </main>
     </>

--- a/algo/firebase/front/src/components/35_taxListDetail/35_taxListDetailMain.tsx
+++ b/algo/firebase/front/src/components/35_taxListDetail/35_taxListDetailMain.tsx
@@ -34,9 +34,9 @@ const TaxListDetailMain = () => {
                         <InputArea<TaxInputFormType> label='申請者名' name='fullName' placeholder='' isEnabled={false} />
                         <InputArea<TaxInputFormType> label='申請者住所' name="address" placeholder='' isEnabled={false} />
                     </Container>
-                    <div className={"relative"}>
+                    <div className={"w-70 mx-auto relative"}>
                         {isIssuing
-                            ? <span className={"absolute right-5 -translate-y-3 text-sm leading-relaxed text-yellow-500"}>VC発行中...</span>
+                            ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC発行中...</span>
                             : null
                         }
                     </div>

--- a/algo/firebase/front/src/components/35_taxListDetail/35_taxListDetailMain.tsx
+++ b/algo/firebase/front/src/components/35_taxListDetail/35_taxListDetailMain.tsx
@@ -20,10 +20,13 @@ const TaxListDetailMain = () => {
                     {VCRequest &&
                         <section className={"flex flex-col items-center gap-1 w-72 mx-auto mb-2 pb-4 border-b"}>
                             {VCRequest.message.content.verifyStatus
-                                ? <p className={"relative text-sm leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
+                                ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
                                 : <p className={"relative text-sm leading-relaxed"}><img src='/warning.svg' className={"absolute -translate-x-full pr-2"} /> 要検証</p>
                             }
-                            <p className={"text-sm text-color-gray-search leading-relaxed"}>{VCRequest.message.content.approvalStatus?"承認済":"未承認"}</p>
+                            {VCRequest.message.content.approvalStatus
+                                ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />承認済</p>
+                                : <p className={"text-sm text-color-required leading-relaxed"}>未承認</p>
+                            }
                             <p className={"text-xs text-color-gray-search leading-relaxed"}>申請日 {dayjs(VCRequest.message.content.applicationDate).format("YY/MM/DD HH:mm")}</p>
                         </section>
                     }
@@ -50,7 +53,7 @@ const TaxListDetailMain = () => {
                             </button>
                             {
                                 VCRequest && VCRequest.message.content.verifyStatus
-                                    ? !VCRequest.message.content.approvalStatus&&
+                                    ? !VCRequest.message.content.approvalStatus &&
                                     <>
                                         <button
                                             onClick={reject}

--- a/algo/firebase/front/src/components/35_taxListDetail/35_taxListDetailMain.tsx
+++ b/algo/firebase/front/src/components/35_taxListDetail/35_taxListDetailMain.tsx
@@ -43,41 +43,39 @@ const TaxListDetailMain = () => {
                             : null
                         }
                     </div>
-                    <Container>
-                        <div className="w-full pt-4 pb-2 px-5 flex justify-between">
-                            <button
-                                onClick={back}
-                                className="input-form-button-white"
-                            >
-                                戻る
-                            </button>
-                            {
-                                VCRequest && VCRequest.message.content.verifyStatus
-                                    ? !VCRequest.message.content.approvalStatus &&
-                                    <>
-                                        <button
-                                            onClick={reject}
-                                            className="input-form-button-white"
-                                        >
-                                            却下
-                                        </button>
-                                        <button
-                                            onClick={approve}
-                                            className="input-form-button-blue"
-                                        >
-                                            承認
-                                        </button>
-                                    </>
-                                    :
+                    <div className="w-70 mx-auto pt-4 pb-2 flex justify-between">
+                        <button
+                            onClick={back}
+                            className="input-form-button-white"
+                        >
+                            戻る
+                        </button>
+                        {
+                            VCRequest && VCRequest.message.content.verifyStatus
+                                ? !VCRequest.message.content.approvalStatus &&
+                                <>
                                     <button
-                                        onClick={verify}
+                                        onClick={reject}
+                                        className="input-form-button-white"
+                                    >
+                                        却下
+                                    </button>
+                                    <button
+                                        onClick={approve}
                                         className="input-form-button-blue"
                                     >
-                                        検証
+                                        承認
                                     </button>
-                            }
-                        </div>
-                    </Container>
+                                </>
+                                :
+                                <button
+                                    onClick={verify}
+                                    className="input-form-button-blue"
+                                >
+                                    検証
+                                </button>
+                        }
+                    </div>
                 </FormProvider>
             </main>
 

--- a/algo/firebase/front/src/components/35_taxListDetail/useTaxListDetailMain.tsx
+++ b/algo/firebase/front/src/components/35_taxListDetail/useTaxListDetailMain.tsx
@@ -4,9 +4,9 @@ import { useRouter } from 'next/router';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ja';
 
-import { TaxInputFormType } from '@/lib/types/mockApp/Form';
+import { TaxInputFormType, TaxVCRequestType } from '@/lib/types/mockApp/Form';
 import { taxInputState, taxVCRequestListState, taxVCListState, VCListState } from '@/lib/states/mockApp';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { verifyVerifiableMessage, createVerifiableCredential, createVerifiableMessage } from '@/lib/algosbt';
 import { getAlgod } from '@/lib/algo/algod/algods';
@@ -23,6 +23,7 @@ const useTaxListDetailMain = () => {
     const setVCList = useSetRecoilState(taxVCListState);
     const setIssuedVCList = useSetRecoilState(VCListState);
     const [isIssuing, setIsIssuing] = useState(false)
+    const [VCRequest, setVCRequest] = useState<TaxVCRequestType>()
     const router = useRouter();
     const errorHandler = useErrorHandler();
     dayjs.locale('ja');
@@ -31,7 +32,12 @@ const useTaxListDetailMain = () => {
     const [holderDidAccountGlobal] = useRecoilState(holderDidAccountState);
     const [issuerDidAccountGlobal] = useRecoilState(issuerDidAccountState);
 
-    const VCRequest = listState.find((v) => v.message.content.id === input.id);
+    useEffect(() => {
+        const VCRequest = listState.find((v) => v.message.content.id === input.id);
+        if(VCRequest){
+            setVCRequest(VCRequest);
+        }
+    })
 
     const methods = useForm<TaxInputFormType>({
         defaultValues: {

--- a/algo/firebase/front/src/components/41_subsidyInput/41_subsidyInputMain.tsx
+++ b/algo/firebase/front/src/components/41_subsidyInput/41_subsidyInputMain.tsx
@@ -40,10 +40,10 @@ const SubsidyInputMain = () => {
                                             </div>
                                         </li>
                                         <li className={"py-3 pl-4 pr-6 w-78 flex"}>
-                                            <VCSelect<SubsidyInputFormType> label={"口座実在証明書"} name={"account"} items={accountList} currentVal={input.account} />
+                                            <VCSelect<SubsidyInputFormType> label={"口座実在証明書"} name={"accountVC"} items={accountList} currentVal={input.accountVC} />
                                         </li>
                                         <li className={"py-3 pl-4 pr-6 w-78 flex"}>
-                                            <VCSelect<SubsidyInputFormType> label={"納税証明書"} name={"tax"} items={taxList} currentVal={input.tax} />
+                                            <VCSelect<SubsidyInputFormType> label={"納税証明書"} name={"taxVC"} items={taxList} currentVal={input.taxVC} />
                                         </li>
                                     </ul>
                                 </Container>

--- a/algo/firebase/front/src/components/41_subsidyInput/useSubsidyInputMain.tsx
+++ b/algo/firebase/front/src/components/41_subsidyInput/useSubsidyInputMain.tsx
@@ -49,7 +49,7 @@ const useSubsidyInputMain = () => {
                     return await verifyVerifiableCredential(algod, item);
                 }));
                 if (residentList[residentList.length - 1]) {
-                    methods.setValue("resident", (VCListGlobal.resident.length - 1).toString());
+                    methods.setValue("residentVC", (VCListGlobal.resident.length - 1).toString());
                     methods.setValue("fullName", VCListGlobal.resident[VCListGlobal.resident.length - 1].message.content.content.fullName);
                     methods.setValue("address", VCListGlobal.resident[VCListGlobal.resident.length - 1].message.content.content.address);
                 } else {

--- a/algo/firebase/front/src/components/41_subsidyInput/useSubsidyInputMain.tsx
+++ b/algo/firebase/front/src/components/41_subsidyInput/useSubsidyInputMain.tsx
@@ -27,9 +27,9 @@ const useSubsidyInputMain = () => {
 
     const methods = useForm<SubsidyInputFormType>({
         defaultValues: {
-            resident: input.resident,
-            account: input.account,
-            tax: input.tax,
+            residentVC: input.residentVC,
+            accountVC: input.accountVC,
+            taxVC: input.taxVC,
             fullName: input.fullName,
             address: input.address,
             verifyStatus: false,
@@ -76,16 +76,16 @@ const useSubsidyInputMain = () => {
 
     const onSubmit = (data: SubsidyInputFormType) => {
 
-        const resident = data.resident ? data.resident : "-1"
-        const account = data.account ? data.account : "-1"
-        const tax = data.tax ? data.tax : "-1"
+        const resident = data.residentVC ? data.residentVC : "-1"
+        const account = data.accountVC ? data.accountVC : "-1"
+        const tax = data.taxVC ? data.taxVC : "-1"
 
         setInput(() => ({
             ...{
                 id: 0,
-                resident: resident,
-                account: account,
-                tax: tax,
+                residentVC: resident,
+                accountVC: account,
+                taxVC: tax,
                 fullName: data.fullName,
                 address: data.address,
                 verifyStatus: false,

--- a/algo/firebase/front/src/components/42_subsidyConfirm/42_subsidyConfirmMain.tsx
+++ b/algo/firebase/front/src/components/42_subsidyConfirm/42_subsidyConfirmMain.tsx
@@ -26,21 +26,21 @@ const SubsidyConfirmMain = () => {
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`住民票 - VC${parseInt(input.resident) + 1}`}
+                                        value={`住民票 - VC${parseInt(input.residentVC) + 1}`}
                                     />
                                 </li>
                                 <li className={"py-3 pl-4 pr-6 w-78 flex"}>
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`口座実在証明証 - VC${parseInt(input.account) + 1}`}
+                                        value={`口座実在証明証 - VC${parseInt(input.accountVC) + 1}`}
                                     />
                                 </li>
                                 <li className={"py-3 pl-4 pr-6 w-78 flex"}>
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`納税証明書 - VC${parseInt(input.tax) + 1}`}
+                                        value={`納税証明書 - VC${parseInt(input.taxVC) + 1}`}
                                     />
                                 </li>
                             </ul>

--- a/algo/firebase/front/src/components/42_subsidyConfirm/useSubsidyConfirmMain.tsx
+++ b/algo/firebase/front/src/components/42_subsidyConfirm/useSubsidyConfirmMain.tsx
@@ -28,9 +28,9 @@ const useSubsidyConfirmMain = () => {
 
     const methods = useForm<SubsidyInputFormType>({
         defaultValues: {
-            resident: input.resident,
-            account: input.account,
-            tax: input.tax,
+            residentVC: input.residentVC,
+            accountVC: input.accountVC,
+            taxVC: input.taxVC,
             fullName: input.fullName,
             address: input.address,
             verifyStatus: false,
@@ -72,8 +72,8 @@ const useSubsidyConfirmMain = () => {
                     applicationDate: applicationDate,
                 }
 
-                if (VCListGlobal.resident && input.resident !== "-1") {
-                    const content = createVPContent(VCListGlobal.resident[parseInt(input.resident)]);
+                if (VCListGlobal.resident && input.residentVC !== "-1") {
+                    const content = createVPContent(VCListGlobal.resident[parseInt(input.residentVC)]);
                     const vm = createVPMessage(
                         content,
                         holderDidAccountGlobal,
@@ -82,8 +82,8 @@ const useSubsidyConfirmMain = () => {
 
                     subsidyInput.residentVP = vm;
                 }
-                if (VCListGlobal.account && input.account !== "-1") {
-                    const content = createVPContent(VCListGlobal.account[parseInt(input.account)]);
+                if (VCListGlobal.account && input.accountVC !== "-1") {
+                    const content = createVPContent(VCListGlobal.account[parseInt(input.accountVC)]);
                     const vm = createVPMessage(
                         content,
                         holderDidAccountGlobal,
@@ -91,8 +91,8 @@ const useSubsidyConfirmMain = () => {
                     );
                     subsidyInput.accountVP = vm;
                 }
-                if (VCListGlobal.tax && input.tax !== "-1") {
-                    const content = createVPContent(VCListGlobal.tax[parseInt(input.tax)]);
+                if (VCListGlobal.tax && input.taxVC !== "-1") {
+                    const content = createVPContent(VCListGlobal.tax[parseInt(input.taxVC)]);
                     const vm = createVPMessage(
                         content,
                         holderDidAccountGlobal,

--- a/algo/firebase/front/src/components/42_subsidyConfirm/useSubsidyConfirmMain.tsx
+++ b/algo/firebase/front/src/components/42_subsidyConfirm/useSubsidyConfirmMain.tsx
@@ -66,20 +66,13 @@ const useSubsidyConfirmMain = () => {
                 const now = dayjs();
                 const applicationDate = dayjs(now).format('YYYY-MM-DD HH:mm:ss');
 
-                const resident = input.resident ? input.resident : "0";
-                const account = input.account ? input.account : "0";
-                const tax = input.resident ? input.tax : "0";
-
                 const subsidyInput: SubsidyInputFormType = {
                     ...input,
                     id: id,
                     applicationDate: applicationDate,
-                    resident: resident,
-                    account: account,
-                    tax: tax,
                 }
 
-                if (VCListGlobal.resident) {
+                if (VCListGlobal.resident && input.resident !== "-1") {
                     const content = createVPContent(VCListGlobal.resident[parseInt(input.resident)]);
                     const vm = createVPMessage(
                         content,
@@ -89,7 +82,7 @@ const useSubsidyConfirmMain = () => {
 
                     subsidyInput.residentVP = vm;
                 }
-                if (VCListGlobal.account) {
+                if (VCListGlobal.account && input.account !== "-1") {
                     const content = createVPContent(VCListGlobal.account[parseInt(input.account)]);
                     const vm = createVPMessage(
                         content,
@@ -98,7 +91,7 @@ const useSubsidyConfirmMain = () => {
                     );
                     subsidyInput.accountVP = vm;
                 }
-                if (VCListGlobal.tax) {
+                if (VCListGlobal.tax && input.tax !== "-1") {
                     const content = createVPContent(VCListGlobal.tax[parseInt(input.tax)]);
                     const vm = createVPMessage(
                         content,

--- a/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
@@ -10,7 +10,7 @@ import useSubsidyListDetailMain from './useSubsidyListDetailMain';
 import dayjs from 'dayjs';
 
 const SubsidyListDetailMain = () => {
-    const { methods, input, onSubmit, reject, verifyHandler, back, isIssuing } = useSubsidyListDetailMain()
+    const { methods, VCRequest, onSubmit, reject, verifyHandler, back, isIssuing } = useSubsidyListDetailMain()
     dayjs.locale('ja');
 
     return (
@@ -20,30 +20,30 @@ const SubsidyListDetailMain = () => {
                 <FormProvider {...methods} >
                     <Container>
                         <div>
-                            {input &&
+                            {VCRequest &&
                                 <section className={"flex flex-col items-center gap-1 w-72 mx-auto mb-2 pb-4 border-b"}>
-                                    {input.verifyStatus
+                                    {VCRequest.verifyStatus
                                         ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
                                         : <p className={"relative text-sm leading-relaxed"}><img src='/warning.svg' className={"absolute -translate-x-full pr-2"} /> 要検証</p>
                                     }
 
-                                    {input.approvalStatus
+                                    {VCRequest.approvalStatus
                                         ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />承認済</p>
                                         : <p className={"text-sm text-color-required leading-relaxed"}>未承認</p>
                                     }
-                                    <p className={"text-xs text-color-gray-search leading-relaxed"}>申請日 {dayjs(input.applicationDate).format("YY/MM/DD HH:mm")}</p>
+                                    <p className={"text-xs text-color-gray-search leading-relaxed"}>申請日 {dayjs(VCRequest.applicationDate).format("YY/MM/DD HH:mm")}</p>
                                 </section>
                             }
                         </div>
                         <Container title={"申請書類の選択"}>
-                            <ul className={"mt-7 ml-3"}>
+                            {VCRequest && <ul className={"mt-7 ml-3"}>
                                 <li className={"py-3 pl-4 pr-6 w-78 flex relative"}>
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`住民票 - VC${parseInt(input.resident) + 1}`}
+                                        value={`住民票 - VC${parseInt(VCRequest.resident) + 1}`}
                                     />
-                                    {input.residentVerifyStatus
+                                    {VCRequest.residentVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />
                                         : <img src='/warning.svg' className={"absolute top-0 right-0 -translate-x-full translate-y-full pr-2"} />
                                     }
@@ -52,9 +52,9 @@ const SubsidyListDetailMain = () => {
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`口座実在証明証 - VC${parseInt(input.account) + 1}`}
+                                        value={`口座実在証明証 - VC${parseInt(VCRequest.account) + 1}`}
                                     />
-                                    {input.accountVerifyStatus
+                                    {VCRequest.accountVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />
                                         : <img src='/warning.svg' className={"absolute top-0 right-0 -translate-x-full translate-y-full pr-2"} />
                                     }
@@ -63,14 +63,15 @@ const SubsidyListDetailMain = () => {
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`納税証明書 - VC${parseInt(input.tax) + 1}`}
+                                        value={`納税証明書 - VC${parseInt(VCRequest.tax) + 1}`}
                                     />
-                                    {input.taxVerifyStatus
+                                    {VCRequest.taxVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />
                                         : <img src='/warning.svg' className={"absolute top-0 right-0 -translate-x-full translate-y-full pr-2"} />
                                     }
                                 </li>
                             </ul>
+                            }
                         </Container>
                         <Container title={"申請者情報"}>
                             <div className={"mt-7 ml-3"}>
@@ -92,8 +93,8 @@ const SubsidyListDetailMain = () => {
                                 戻る
                             </button>
                             {
-                                input && input.verifyStatus
-                                    ? !input.approvalStatus &&
+                                VCRequest && VCRequest.verifyStatus
+                                    ? !VCRequest.approvalStatus &&
                                     <>
                                         <button
                                             onClick={reject}

--- a/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
@@ -93,28 +93,19 @@ const SubsidyListDetailMain = () => {
                                 戻る
                             </button>
                             {
-                                VCRequest && VCRequest.verifyStatus
-                                    ? !VCRequest.approvalStatus &&
-                                    <>
-                                        <button
-                                            onClick={reject}
-                                            className="input-form-button-white"
-                                        >
-                                            却下
-                                        </button>
-                                        <button
-                                            onClick={onSubmit}
-                                            className="input-form-button-orange"
-                                        >
-                                            承認
-                                        </button>
-                                    </>
-                                    :
-                                    <button
-                                        onClick={verifyHandler}
+                                VCRequest && VCRequest.verifyStatus && !VCRequest.approvalStatus
+                                    ? <button
+                                        onClick={onSubmit}
                                         className="input-form-button-orange"
                                     >
-                                        検証
+                                        承認
+                                    </button>
+                                    :
+                                    <button
+                                        onClick={reject}
+                                        className="input-form-button-white"
+                                    >
+                                        却下
                                     </button>
                             }
                         </div>

--- a/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
@@ -41,7 +41,7 @@ const SubsidyListDetailMain = () => {
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`住民票 - VC${parseInt(VCRequest.resident) + 1}`}
+                                        value={`住民票 - VC${parseInt(VCRequest.residentVC) + 1}`}
                                     />
                                     {VCRequest.residentVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />
@@ -52,7 +52,7 @@ const SubsidyListDetailMain = () => {
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`口座実在証明証 - VC${parseInt(VCRequest.account) + 1}`}
+                                        value={`口座実在証明証 - VC${parseInt(VCRequest.accountVC) + 1}`}
                                     />
                                     {VCRequest.accountVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />
@@ -63,7 +63,7 @@ const SubsidyListDetailMain = () => {
                                     <input type="text"
                                         className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                         disabled={true}
-                                        value={`納税証明書 - VC${parseInt(VCRequest.tax) + 1}`}
+                                        value={`納税証明書 - VC${parseInt(VCRequest.taxVC) + 1}`}
                                     />
                                     {VCRequest.taxVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />

--- a/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
@@ -3,14 +3,13 @@ import { FormProvider } from 'react-hook-form';
 import Container from '@/components/common/Container';
 import Header from '@/components/common/Header';
 import InputArea from '@/components/common/InputArea';
-import CheckBox from '@/components/common/CheckBox';
 
 import { SubsidyInputFormType } from '@/lib/types/mockApp/Form';
 import useSubsidyListDetailMain from './useSubsidyListDetailMain';
 import dayjs from 'dayjs';
 
 const SubsidyListDetailMain = () => {
-    const { methods, VCRequest, onSubmit, reject, verifyHandler, back, isIssuing } = useSubsidyListDetailMain()
+    const { methods, VCRequest, onSubmit, reject, verifyHandler, back, isIssuing, residentVerifyStatus, accountVerifyStatus, taxVerifyStatus } = useSubsidyListDetailMain()
     dayjs.locale('ja');
 
     return (
@@ -43,7 +42,7 @@ const SubsidyListDetailMain = () => {
                                         disabled={true}
                                         value={`住民票 - VC${parseInt(VCRequest.residentVC) + 1}`}
                                     />
-                                    {VCRequest.residentVerifyStatus
+                                    {residentVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />
                                         : <img src='/warning.svg' className={"absolute top-0 right-0 -translate-x-full translate-y-full pr-2"} />
                                     }
@@ -54,7 +53,7 @@ const SubsidyListDetailMain = () => {
                                         disabled={true}
                                         value={`口座実在証明証 - VC${parseInt(VCRequest.accountVC) + 1}`}
                                     />
-                                    {VCRequest.accountVerifyStatus
+                                    {accountVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />
                                         : <img src='/warning.svg' className={"absolute top-0 right-0 -translate-x-full translate-y-full pr-2"} />
                                     }
@@ -65,7 +64,7 @@ const SubsidyListDetailMain = () => {
                                         disabled={true}
                                         value={`納税証明書 - VC${parseInt(VCRequest.taxVC) + 1}`}
                                     />
-                                    {VCRequest.taxVerifyStatus
+                                    {taxVerifyStatus
                                         ? <img src='/authenticated.svg' className={"absolute top-0 right-0 -translate-x-1/2 translate-y-2"} />
                                         : <img src='/warning.svg' className={"absolute top-0 right-0 -translate-x-full translate-y-full pr-2"} />
                                     }

--- a/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
@@ -92,20 +92,23 @@ const SubsidyListDetailMain = () => {
                                 戻る
                             </button>
                             {
-                                VCRequest && VCRequest.verifyStatus && !VCRequest.approvalStatus
-                                    ? <button
-                                        onClick={onSubmit}
-                                        className="input-form-button-orange"
-                                    >
-                                        承認
-                                    </button>
-                                    :
-                                    <button
-                                        onClick={reject}
-                                        className="input-form-button-white"
-                                    >
-                                        却下
-                                    </button>
+                                VCRequest && !VCRequest.approvalStatus
+                                    ? VCRequest.verifyStatus
+                                        ?
+                                        <button
+                                            onClick={onSubmit}
+                                            className="input-form-button-orange"
+                                        >
+                                            承認
+                                        </button>
+                                        :
+                                        <button
+                                            onClick={reject}
+                                            className="input-form-button-white"
+                                        >
+                                            却下
+                                        </button>
+                                    : null
                             }
                         </div>
                     </Container>

--- a/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
@@ -23,10 +23,14 @@ const SubsidyListDetailMain = () => {
                             {input &&
                                 <section className={"flex flex-col items-center gap-1 w-72 mx-auto mb-2 pb-4 border-b"}>
                                     {input.verifyStatus
-                                        ? <p className={"relative text-sm leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
+                                        ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />検証済</p>
                                         : <p className={"relative text-sm leading-relaxed"}><img src='/warning.svg' className={"absolute -translate-x-full pr-2"} /> 要検証</p>
                                     }
-                                    <p className={"text-sm text-color-gray-search leading-relaxed"}>{input.approvalStatus ? "承認済" : "未承認"}</p>
+
+                                    {input.approvalStatus
+                                        ? <p className={"relative text-sm text-color-gray-search leading-relaxed"}><img src='/authenticated.svg' className={"absolute top-0 -translate-y-3 -translate-x-full"} />承認済</p>
+                                        : <p className={"text-sm text-color-required leading-relaxed"}>未承認</p>
+                                    }
                                     <p className={"text-xs text-color-gray-search leading-relaxed"}>申請日 {dayjs(input.applicationDate).format("YY/MM/DD HH:mm")}</p>
                                 </section>
                             }

--- a/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/45_subsidyListDetailMain.tsx
@@ -74,9 +74,9 @@ const SubsidyListDetailMain = () => {
                                 <InputArea<SubsidyInputFormType> label='申請者住所' name="address" placeholder='' isEnabled={false} />
                             </div>
                         </Container>
-                        <div className={"relative"}>
+                        <div className={"w-70 mx-auto relative"}>
                             {isIssuing
-                                ? <span className={"absolute right-5 -translate-y-3 text-sm leading-relaxed text-yellow-500"}>承認中...</span>
+                                ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC発行中...</span>
                                 : null
                             }
                         </div>

--- a/algo/firebase/front/src/components/45_subsidyListDetail/useSubsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/useSubsidyListDetailMain.tsx
@@ -36,6 +36,20 @@ const useSubsidyListDetailMain = () => {
 
     dayjs.locale('ja');
 
+    useEffect(() => {
+        try {
+            (async () => {
+                verifyHandler();
+                const VCRequest = listState.find((v) => v.id === input.id);
+                if (VCRequest) {
+                    setVCRequest(VCRequest);
+                }
+            })();
+        } catch (e) {
+            errorHandler(e);
+        }
+    }, [chain])
+
 
 
     const methods = useForm<SubsidyInputFormType>({
@@ -105,20 +119,6 @@ const useSubsidyListDetailMain = () => {
         }
     }
 
-    useEffect(() => {
-        try {
-            (async () => {
-                const VCRequest = listState.find((v) => v.id === input.id);
-                if (VCRequest) {
-                    setVCRequest(VCRequest);
-                    verifyHandler();
-                }
-            })();
-        } catch (e) {
-            errorHandler(e);
-        }
-    }, [chain])
-
     const onSubmit = async () => {
         try {
             setIsIssuing(() => true);
@@ -170,7 +170,7 @@ const useSubsidyListDetailMain = () => {
     };
     // verifyHandler();
 
-    return { methods, VCRequest, onSubmit, reject, verifyHandler, back, isIssuing, residentVerifyStatus, accountVerifyStatus, taxVerifyStatus }
+    return { methods, input, VCRequest, onSubmit, reject, verifyHandler, back, isIssuing, residentVerifyStatus, accountVerifyStatus, taxVerifyStatus }
 };
 
 export default useSubsidyListDetailMain;

--- a/algo/firebase/front/src/components/45_subsidyListDetail/useSubsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/useSubsidyListDetailMain.tsx
@@ -37,8 +37,11 @@ const useSubsidyListDetailMain = () => {
         const VCRequest = listState.find((v) => v.id === input.id);
         if (VCRequest) {
             setVCRequest(VCRequest);
+            if (!VCRequest.verifyStatus) {
+                verifyHandler();
+            }
         }
-    })
+    }, [VCRequest])
 
     const methods = useForm<SubsidyInputFormType>({
         defaultValues: {

--- a/algo/firebase/front/src/components/45_subsidyListDetail/useSubsidyListDetailMain.tsx
+++ b/algo/firebase/front/src/components/45_subsidyListDetail/useSubsidyListDetailMain.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useRouter } from 'next/router';
 
-import { SubsidyInputFormType, VPContent } from '@/lib/types/mockApp/Form';
+import { SubsidyInputFormType, SubsidyVCRequestType, VPContent } from '@/lib/types/mockApp/Form';
 import { subsidyInputState } from '@/lib/states/mockApp/subsidyInputState';
 import { subsidyListState } from '@/lib/states/mockApp/subsidyListState';
 
@@ -16,7 +16,7 @@ import { issuerPw } from '@/lib/algo/account/accounts';
 import holderDidAccountState from '@/lib/states/holderDidAccountState';
 import issuerDidAccountState from '@/lib/states/issuerDidAccountState';
 import { VCListState } from '@/lib/states/mockApp';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 
 const useSubsidyListDetailMain = () => {
@@ -25,12 +25,20 @@ const useSubsidyListDetailMain = () => {
     const [isIssuing, setIsIssuing] = useState(false);
     const setVCList = useSetRecoilState(VCListState);
     const router = useRouter();
+    const [VCRequest, setVCRequest] = useState<SubsidyInputFormType>()
     const errorHandler = useErrorHandler();
     const [chain] = useRecoilState(chainState);
     const [holderDidAccountGlobal] = useRecoilState(holderDidAccountState);
     const [issuerDidAccountGlobal] = useRecoilState(issuerDidAccountState);
 
     dayjs.locale('ja');
+
+    useEffect(() => {
+        const VCRequest = listState.find((v) => v.id === input.id);
+        if (VCRequest) {
+            setVCRequest(VCRequest);
+        }
+    })
 
     const methods = useForm<SubsidyInputFormType>({
         defaultValues: {
@@ -146,7 +154,7 @@ const useSubsidyListDetailMain = () => {
         router.push('/44_subsidyList')
     };
 
-    return { methods, input, onSubmit, reject, verifyHandler, back, isIssuing }
+    return { methods, VCRequest, onSubmit, reject, verifyHandler, back, isIssuing }
 };
 
 export default useSubsidyListDetailMain;

--- a/algo/firebase/front/src/components/61_VCList/useVCListMain.tsx
+++ b/algo/firebase/front/src/components/61_VCList/useVCListMain.tsx
@@ -7,6 +7,7 @@ import dayjs from 'dayjs';
 import chainState from '@/lib/states/chainState';
 import { getAlgod } from '@/lib/algo/algod/algods';
 import { verifyVerifiableCredential } from '@/lib/algosbt';
+import { useErrorHandler } from 'react-error-boundary';
 
 const useVCListMain = () => {
     const VCListGlobal = useRecoilValue(VCListState);
@@ -16,51 +17,56 @@ const useVCListMain = () => {
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
     const chain = useRecoilValue(chainState);
+    const errorHandler = useErrorHandler();
     dayjs.locale('ja');
 
     useEffect(() => {
         (async () => {
-            setIsLoading(() => true);
+            try {
+                setIsLoading(() => true);
 
-            const algod = getAlgod(chain);
+                const algod = getAlgod(chain);
 
-            if (VCListGlobal.resident) {
-                const residentList: VCListItem[] = await Promise.all(VCListGlobal.resident.map(async (item) => {
-                    const revokeStatus = await verifyVerifiableCredential(algod, item);
-                    return {
-                        id: item.message.content.content.id,
-                        applicationDate: item.message.content.content.applicationDate,
-                        issueDate: item.message.content.content.issueDate,
-                        revokeStatus: revokeStatus,
-                    }
-                }));
-                setResidentList(sortList(residentList));
+                if (VCListGlobal.resident) {
+                    const residentList: VCListItem[] = await Promise.all(VCListGlobal.resident.map(async (item) => {
+                        const revokeStatus = await verifyVerifiableCredential(algod, item);
+                        return {
+                            id: item.message.content.content.id,
+                            applicationDate: item.message.content.content.applicationDate,
+                            issueDate: item.message.content.content.issueDate,
+                            revokeStatus: revokeStatus,
+                        }
+                    }));
+                    setResidentList(sortList(residentList));
+                }
+                if (VCListGlobal.account) {
+                    const accountList: VCListItem[] = await Promise.all(VCListGlobal.account.map(async (item) => {
+                        const revokeStatus = await verifyVerifiableCredential(algod, item);
+                        return {
+                            id: item.message.content.content.id,
+                            applicationDate: item.message.content.content.applicationDate,
+                            issueDate: item.message.content.content.issueDate,
+                            revokeStatus: revokeStatus,
+                        }
+                    }));
+                    setAccountList(sortList(accountList));
+                }
+                if (VCListGlobal.tax) {
+                    const taxList: VCListItem[] = await Promise.all(VCListGlobal.tax.map(async (item) => {
+                        const revokeStatus = await verifyVerifiableCredential(algod, item);
+                        return {
+                            id: item.message.content.content.id,
+                            applicationDate: item.message.content.content.applicationDate,
+                            issueDate: item.message.content.content.issueDate,
+                            revokeStatus: revokeStatus,
+                        }
+                    }));
+                    setTaxList(sortList(taxList));
+                }
+                setIsLoading(() => false);
+            } catch (e) {
+                errorHandler(e);
             }
-            if (VCListGlobal.account) {
-                const accountList: VCListItem[] = await Promise.all(VCListGlobal.account.map(async (item) => {
-                    const revokeStatus = await verifyVerifiableCredential(algod, item);
-                    return {
-                        id: item.message.content.content.id,
-                        applicationDate: item.message.content.content.applicationDate,
-                        issueDate: item.message.content.content.issueDate,
-                        revokeStatus: revokeStatus,
-                    }
-                }));
-                setAccountList(sortList(accountList));
-            }
-            if (VCListGlobal.tax) {
-                const taxList: VCListItem[] = await Promise.all(VCListGlobal.tax.map(async (item) => {
-                    const revokeStatus = await verifyVerifiableCredential(algod, item);
-                    return {
-                        id: item.message.content.content.id,
-                        applicationDate: item.message.content.content.applicationDate,
-                        issueDate: item.message.content.content.issueDate,
-                        revokeStatus: revokeStatus,
-                    }
-                }));
-                setTaxList(sortList(taxList));
-            }
-            setIsLoading(() => false);
         })();
     }, [VCListGlobal, chain]);
 

--- a/algo/firebase/front/src/components/62_VCInquiry/useVCInquiryMain.tsx
+++ b/algo/firebase/front/src/components/62_VCInquiry/useVCInquiryMain.tsx
@@ -9,6 +9,7 @@ import 'dayjs/locale/ja';
 import { getAlgod } from '@/lib/algo/algod/algods';
 import chainState from '@/lib/states/chainState';
 import { verifyVerifiableCredential } from '@/lib/algosbt';
+import { useErrorHandler } from 'react-error-boundary';
 
 const useVCInquiryMain = () => {
     const router = useRouter();
@@ -23,44 +24,49 @@ const useVCInquiryMain = () => {
     const [accountInput, setAccountInput] = useState<AccountInputFormType>()
     const [taxInput, setTaxInput] = useState<TaxInputFormType>()
     const chain = useRecoilValue(chainState);
+    const errorHandler = useErrorHandler();
     dayjs.locale('ja');
 
     useEffect(() => {
         (async () => {
-            setIsLoading(() => true);
+            try {
+                setIsLoading(() => true);
 
-            const algod = getAlgod(chain);
+                const algod = getAlgod(chain);
 
-            if (typeof router.query.idx === "string" && typeof router.query.type === "string") {
-                setType(router.query.type)
-                setIdx(parseInt(router.query.idx))
-                if (router.query.type === "住民票") {
-                    const VC = VCListGlobal.resident[parseInt(router.query.idx) - 1];
-                    setResidentInput(VC.message.content.content);
-                    setApplicationDate(dayjs(VC.message.content.content.applicationDate).format("YY/MM/DD HH:mm"));
-                    setIssueDate(dayjs(VC.message.content.content.issueDate).format("YY/MM/DD HH:mm"));
-                    const revoke = await verifyVerifiableCredential(algod, VC);
-                    setRevokeStatus(revoke);
+                if (typeof router.query.idx === "string" && typeof router.query.type === "string") {
+                    setType(router.query.type)
+                    setIdx(parseInt(router.query.idx))
+                    if (router.query.type === "住民票") {
+                        const VC = VCListGlobal.resident[parseInt(router.query.idx) - 1];
+                        setResidentInput(VC.message.content.content);
+                        setApplicationDate(dayjs(VC.message.content.content.applicationDate).format("YY/MM/DD HH:mm"));
+                        setIssueDate(dayjs(VC.message.content.content.issueDate).format("YY/MM/DD HH:mm"));
+                        const revoke = await verifyVerifiableCredential(algod, VC);
+                        setRevokeStatus(revoke);
+                    }
+                    else if (router.query.type === "口座実在証明書") {
+                        const VC = VCListGlobal.account[parseInt(router.query.idx) - 1];
+                        setAccountInput(VC.message.content.content);
+                        setApplicationDate(dayjs(VC.message.content.content.applicationDate).format("YY/MM/DD HH:mm"));
+                        setIssueDate(dayjs(VC.message.content.content.issueDate).format("YY/MM/DD HH:mm"));
+                        const revoke = await verifyVerifiableCredential(algod, VC);
+                        setRevokeStatus(revoke);
+                    }
+                    else if (router.query.type === "納税証明書") {
+                        const VC = VCListGlobal.tax[parseInt(router.query.idx) - 1];
+                        setTaxInput(VC.message.content.content);
+                        setApplicationDate(dayjs(VC.message.content.content.applicationDate).format("YY/MM/DD HH:mm"));
+                        setIssueDate(dayjs(VC.message.content.content.issueDate).format("YY/MM/DD HH:mm"));
+                        const revoke = await verifyVerifiableCredential(algod, VC);
+                        setRevokeStatus(revoke);
+                    }
                 }
-                else if (router.query.type === "口座実在証明書") {
-                    const VC = VCListGlobal.account[parseInt(router.query.idx) - 1];
-                    setAccountInput(VC.message.content.content);
-                    setApplicationDate(dayjs(VC.message.content.content.applicationDate).format("YY/MM/DD HH:mm"));
-                    setIssueDate(dayjs(VC.message.content.content.issueDate).format("YY/MM/DD HH:mm"));
-                    const revoke = await verifyVerifiableCredential(algod, VC);
-                    setRevokeStatus(revoke);
-                }
-                else if (router.query.type === "納税証明書") {
-                    const VC = VCListGlobal.tax[parseInt(router.query.idx) - 1];
-                    setTaxInput(VC.message.content.content);
-                    setApplicationDate(dayjs(VC.message.content.content.applicationDate).format("YY/MM/DD HH:mm"));
-                    setIssueDate(dayjs(VC.message.content.content.issueDate).format("YY/MM/DD HH:mm"));
-                    const revoke = await verifyVerifiableCredential(algod, VC);
-                    setRevokeStatus(revoke);
-                }
+
+                setIsLoading(() => false);
+            } catch (e) {
+                errorHandler(e)
             }
-
-            setIsLoading(() => false);
         })();
     }, [VCListGlobal, router.query, chain]);
 

--- a/algo/firebase/front/src/components/71_ApplicationList/useApplicationListMain.tsx
+++ b/algo/firebase/front/src/components/71_ApplicationList/useApplicationListMain.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue } from "recoil";
 import { RequestItem } from "../common/ApplicationListContainer/ApplicationListContainer";
 import chainState from '@/lib/states/chainState';
 import { getAlgod } from "@/lib/algo/algod/algods";
+import { useErrorHandler } from "react-error-boundary";
 
 const useApplicationListMain = () => {
     const [residentList, setResidentList] = useState<RequestItem[]>([]);
@@ -19,98 +20,105 @@ const useApplicationListMain = () => {
     const subsidyRequestGlobal = useRecoilValue(subsidyListState);
     const VCList = useRecoilValue(VCListState);
     const chain = useRecoilValue(chainState);
+    const errorHandler = useErrorHandler();
 
 
     useEffect(() => {
-        (async () => {
-            setIsLoading(() => true);
+        try {
+            (async () => {
+                setIsLoading(() => true);
 
-            const algod = getAlgod(chain);
+                const algod = getAlgod(chain);
 
-            if (residentRequestGlobal) {
-                const residentList: RequestItem[] = await Promise.all(residentRequestGlobal.map(async (item) => {
-                    let issuedStatus = false;
-                    let revokeStatus = false;
-                    if (VCList.resident) {
-                        const residentVC = VCList.resident.find((vc) => { return vc.message.content.content.id === item.message.content.id });
-                        if (residentVC) {
-                            issuedStatus = true;
-                            revokeStatus = await verifyVerifiableCredential(algod, residentVC);
+                if (residentRequestGlobal) {
+                    const residentList: RequestItem[] = await Promise.all(residentRequestGlobal.map(async (item) => {
+                        let issuedStatus = false;
+                        let revokeStatus = false;
+                        if (VCList.resident) {
+                            const residentVC = VCList.resident.find((vc) => { return vc.message.content.content.id === item.message.content.id });
+                            if (residentVC) {
+                                issuedStatus = true;
+                                revokeStatus = await verifyVerifiableCredential(algod, residentVC);
+                            }
                         }
-                    }
-                    return {
-                        id: item.message.content.id,
-                        applicationDate: item.message.content.applicationDate,
-                        issuedStatus: issuedStatus,
-                        revokeStatus: revokeStatus,
-                    }
-                }));
-                setResidentList(residentList);
-            }
+                        return {
+                            id: item.message.content.id,
+                            applicationDate: item.message.content.applicationDate,
+                            issuedStatus: issuedStatus,
+                            revokeStatus: revokeStatus,
+                        }
+                    }));
+                    setResidentList(residentList);
+                }
 
-            if (accountRequestGlobal) {
-                const accountList = await Promise.all(accountRequestGlobal.map(async (item) => {
-                    let issuedStatus = false;
-                    let revokeStatus = false;
-                    if (VCList.account) {
-                        const accountVC = VCList.account.find((vc) => { return vc.message.content.content.id === item.message.content.id });
-                        if (accountVC) {
-                            issuedStatus = true;
-                            revokeStatus = await verifyVerifiableCredential(algod, accountVC);
+                if (accountRequestGlobal) {
+                    const accountList = await Promise.all(accountRequestGlobal.map(async (item) => {
+                        let issuedStatus = false;
+                        let revokeStatus = false;
+                        if (VCList.account) {
+                            const accountVC = VCList.account.find((vc) => { return vc.message.content.content.id === item.message.content.id });
+                            if (accountVC) {
+                                issuedStatus = true;
+                                revokeStatus = await verifyVerifiableCredential(algod, accountVC);
+                            }
                         }
-                    }
-                    return {
-                        id: item.message.content.id,
-                        applicationDate: item.message.content.applicationDate,
-                        issuedStatus: issuedStatus,
-                        revokeStatus: revokeStatus,
-                    }
-                }));
-                setAccountList(accountList);
-            }
+                        return {
+                            id: item.message.content.id,
+                            applicationDate: item.message.content.applicationDate,
+                            issuedStatus: issuedStatus,
+                            revokeStatus: revokeStatus,
+                        }
+                    }));
+                    setAccountList(accountList);
+                }
 
-            if (taxRequestGlobal) {
-                const taxList = await Promise.all(taxRequestGlobal.map(async (item) => {
-                    let issuedStatus = false;
-                    let revokeStatus = false;
-                    if (VCList.tax) {
-                        const taxVC = VCList.tax.find((vc) => { return vc.message.content.content.id === item.message.content.id });
-                        if (taxVC) {
-                            issuedStatus = true;
-                            revokeStatus = await verifyVerifiableCredential(algod, taxVC);
+                if (taxRequestGlobal) {
+                    const taxList = await Promise.all(taxRequestGlobal.map(async (item) => {
+                        let issuedStatus = false;
+                        let revokeStatus = false;
+                        if (VCList.tax) {
+                            const taxVC = VCList.tax.find((vc) => { return vc.message.content.content.id === item.message.content.id });
+                            if (taxVC) {
+                                issuedStatus = true;
+                                revokeStatus = await verifyVerifiableCredential(algod, taxVC);
+                            }
                         }
-                    }
-                    return {
-                        id: item.message.content.id,
-                        applicationDate: item.message.content.applicationDate,
-                        issuedStatus: issuedStatus,
-                        revokeStatus: revokeStatus,
-                    }
-                }));
-                setTaxList(taxList);
-            }
-            if (subsidyRequestGlobal) {
-                const subsidyList = await Promise.all(subsidyRequestGlobal.map(async (item) => {
-                    let issuedStatus = false;
-                    let revokeStatus = false;
-                    if (VCList.subsidy) {
-                        const subsidyVC = VCList.subsidy.find((vc) => { return vc.message.content.content.id === item.id });
-                        if (subsidyVC) {
-                            issuedStatus = true;
-                            revokeStatus = await verifyVerifiableCredential(algod, subsidyVC);
+                        return {
+                            id: item.message.content.id,
+                            applicationDate: item.message.content.applicationDate,
+                            issuedStatus: issuedStatus,
+                            revokeStatus: revokeStatus,
                         }
-                    }
-                    return {
-                        id: item.id,
-                        applicationDate: item.applicationDate,
-                        issuedStatus: issuedStatus,
-                        revokeStatus: revokeStatus,
-                    }
-                }));
-                setSubsidyList(subsidyList);
-            }
-            setIsLoading(() => false);
-        })();
+                    }));
+                    setTaxList(taxList);
+                }
+                if (subsidyRequestGlobal) {
+                    const subsidyList = await Promise.all(subsidyRequestGlobal.map(async (item) => {
+                        let issuedStatus = false;
+                        let revokeStatus = false;
+                        if (VCList.subsidy) {
+                            const subsidyVC = VCList.subsidy.find((vc) => { return vc.message.content.content.id === item.id });
+                            if (subsidyVC) {
+                                issuedStatus = true;
+                                revokeStatus = await verifyVerifiableCredential(algod, subsidyVC);
+                            }
+                        }
+                        return {
+                            id: item.id,
+                            applicationDate: item.applicationDate,
+                            issuedStatus: issuedStatus,
+                            revokeStatus: revokeStatus,
+                        }
+                    }));
+                    setSubsidyList(subsidyList);
+                }
+                setIsLoading(() => false);
+
+            })()
+        }
+        catch (e) {
+            errorHandler(e);
+        }
 
     }, [residentRequestGlobal, accountRequestGlobal, taxRequestGlobal, subsidyRequestGlobal, VCList, chain]);
 

--- a/algo/firebase/front/src/components/72_ApplicationListDetail/SubsidyInquiry.tsx
+++ b/algo/firebase/front/src/components/72_ApplicationListDetail/SubsidyInquiry.tsx
@@ -12,9 +12,9 @@ export type SubsidyInquiryParams = {
 const SubsidyInquiry = ({ input }: SubsidyInquiryParams) => {
     const methods = useForm<SubsidyInputFormType>({
         defaultValues: {
-            resident: input.resident,
-            account: input.account,
-            tax: input.tax,
+            residentVC: input.residentVC,
+            accountVC: input.accountVC,
+            taxVC: input.taxVC,
             fullName: input.fullName,
             address: input.address,
             verifyStatus: false,
@@ -31,21 +31,21 @@ const SubsidyInquiry = ({ input }: SubsidyInquiryParams) => {
                             <input type="text"
                                 className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                 disabled={true}
-                                value={`住民票 - VC${parseInt(input.resident) + 1}`}
+                                value={`住民票 - VC${parseInt(input.residentVC) + 1}`}
                             />
                         </li>
                         <li className={"py-3 pl-4 pr-6 w-78 flex"}>
                             <input type="text"
                                 className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                 disabled={true}
-                                value={`口座実在証明証 - VC${parseInt(input.account) + 1}`}
+                                value={`口座実在証明証 - VC${parseInt(input.accountVC) + 1}`}
                             />
                         </li>
                         <li className={"py-3 pl-4 pr-6 w-78 flex"}>
                             <input type="text"
                                 className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                 disabled={true}
-                                value={`納税証明書 - VC${parseInt(input.tax) + 1}`}
+                                value={`納税証明書 - VC${parseInt(input.taxVC) + 1}`}
                             />
                         </li>
                     </ul>

--- a/algo/firebase/front/src/components/82_residentVCListDetail/82_residentVCListDetailMain.tsx
+++ b/algo/firebase/front/src/components/82_residentVCListDetail/82_residentVCListDetailMain.tsx
@@ -73,13 +73,13 @@ const ResidentVCListDetailMain = () => {
               </div>
             </section>
             <ResidentInquiry input={input} />
-            <div className={"relative w-80 mx-auto"}>
+            <div className={"relative w-70 mx-auto"}>
               {isRevoking
                 ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC取消中...</span>
                 : null
               }
             </div>
-            <div className="py-0 px-[53px]">
+            <div className="w-70 mx-auto py-0">
               <div className="pt-4 pb-2 flex justify-between">
                 <button
                   onClick={() => router.push("/81_residentVCList")}

--- a/algo/firebase/front/src/components/92_accountVCListDetail/92_accountVCListDetailMain.tsx
+++ b/algo/firebase/front/src/components/92_accountVCListDetail/92_accountVCListDetailMain.tsx
@@ -74,13 +74,13 @@ const AccountVCListDetailMain = () => {
               </div>
             </section>
             <AccountInquiry input={input} />
-            <div className={"relative w-80 mx-auto"}>
+            <div className={"relative w-70 mx-auto"}>
               {isRevoking
                 ? <span className={"absolute right-0 -translate-y-1/2 text-sm leading-relaxed text-yellow-500"}>VC取消中...</span>
                 : null
               }
             </div>
-            <div className="py-0 px-[53px]">
+            <div className="w-70 mx-auto py-0">
               <div className="pt-4 pb-2 flex justify-between">
                 <button
                   onClick={() => router.push("/91_accountVCList")}

--- a/algo/firebase/front/src/components/common/Forms/SubsidyInquiry.tsx
+++ b/algo/firebase/front/src/components/common/Forms/SubsidyInquiry.tsx
@@ -12,9 +12,9 @@ export type SubsidyInquiryParams = {
 const SubsidyInquiry = ({ input }: SubsidyInquiryParams) => {
     const methods = useForm<SubsidyInputFormType>({
         defaultValues: {
-            resident: input.resident,
-            account: input.account,
-            tax: input.tax,
+            residentVC: input.residentVC,
+            accountVC: input.accountVC,
+            taxVC: input.taxVC,
             fullName: input.fullName,
             address: input.address,
             verifyStatus: false,
@@ -31,21 +31,21 @@ const SubsidyInquiry = ({ input }: SubsidyInquiryParams) => {
                             <input type="text"
                                 className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                 disabled={true}
-                                value={`住民票 - VC${parseInt(input.resident) + 1}`}
+                                value={`住民票 - VC${parseInt(input.residentVC) + 1}`}
                             />
                         </li>
                         <li className={"py-3 pl-4 pr-6 w-78 flex"}>
                             <input type="text"
                                 className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                 disabled={true}
-                                value={`口座実在証明証 - VC${parseInt(input.account) + 1}`}
+                                value={`口座実在証明証 - VC${parseInt(input.accountVC) + 1}`}
                             />
                         </li>
                         <li className={"py-3 pl-4 pr-6 w-78 flex"}>
                             <input type="text"
                                 className={"w-[281px] h-[44px] px-2 rounded-lg text-base bg-color-disabled"}
                                 disabled={true}
-                                value={`納税証明書 - VC${parseInt(input.tax) + 1}`}
+                                value={`納税証明書 - VC${parseInt(input.taxVC) + 1}`}
                             />
                         </li>
                     </ul>

--- a/algo/firebase/front/src/components/common/Header/Header.tsx
+++ b/algo/firebase/front/src/components/common/Header/Header.tsx
@@ -4,7 +4,7 @@ import useHeader from "./useHeader";
 import Head from 'next/head';
 
 const Header = () => {
-    const { getHeading, getBgColor, getIcon, getLink, getTitle } = useHeader()
+    const { getHeading, getBgColor, getIcon, getLink, getTitle, back } = useHeader()
 
     const heading = getHeading();
     const bgColor = getBgColor();
@@ -20,14 +20,22 @@ const Header = () => {
                 </Head>
             }
             <header>
-                <div className={`flex w-full h-16 py-5 px-5 ${bgColor}`}>
-                    {icon && <img src={icon} alt="アイコン" className={"pr-2"} />}
-                    <h1 className={"text-white text-lg font-bold"}>{heading}</h1>
-                    {url && <Link href={url}>
-                        <a className={"w-[62px] h-[34px] bg-white ml-auto text-[15px] font-bold leading-[34px] text-center text-color-menu-button-text uppercase border border-color-menu-button rounded-lg"} >
-                            {label}
-                        </a>
-                    </Link>}
+                <div className={`flex items-center justify-between w-full h-16 py-5 px-5 ${bgColor}`}>
+                    <a onClick={back} className={"w-[62px] h-[34px] bg-white text-[15px] font-bold leading-[34px] text-center text-color-menu-button-text uppercase border border-color-menu-button rounded-lg"} >
+                        Back
+                    </a>
+                    <div className="flex">
+                        {icon && <img src={icon} alt="アイコン" className={"pr-2"} />}
+                        <h1 className={"text-white text-lg font-bold"}>{heading}</h1>
+                    </div>
+                    <div className={"w-fit h-fit flex justify-between gap-2"}>
+                        {url ? <Link href={url}>
+                            <a className={"w-[62px] h-[34px] bg-white text-[15px] font-bold leading-[34px] text-center text-color-menu-button-text uppercase border border-color-menu-button rounded-lg"} >
+                                {label}
+                            </a>
+                        </Link>
+                            : <div className="w-[62px]"></div>}
+                    </div>
                 </div>
                 <PageTitle />
             </header>

--- a/algo/firebase/front/src/components/common/Header/useHeader.tsx
+++ b/algo/firebase/front/src/components/common/Header/useHeader.tsx
@@ -11,6 +11,10 @@ const useHeader = () => {
         clearOldData();
     }, [clearOldData])
 
+    const back = () => {
+        router.back();
+    }
+
     const Headings = {
         mainMenu: "DEMO MENU",
         applierMenu: "申請者",
@@ -332,7 +336,7 @@ const useHeader = () => {
         }
     }
 
-    return { getHeading, getBgColor, getIcon, getLink, getTitle }
+    return { getHeading, getBgColor, getIcon, getLink, getTitle, back }
 };
 
 export default useHeader;

--- a/algo/firebase/front/src/components/common/Header/useHeader.tsx
+++ b/algo/firebase/front/src/components/common/Header/useHeader.tsx
@@ -9,7 +9,7 @@ const useHeader = () => {
 
     useEffect(() => {
         clearOldData();
-    },)
+    },[clearOldData])
 
     const Headings = {
         mainMenu: "DEMO MENU",

--- a/algo/firebase/front/src/components/common/Header/useHeader.tsx
+++ b/algo/firebase/front/src/components/common/Header/useHeader.tsx
@@ -9,7 +9,7 @@ const useHeader = () => {
 
     useEffect(() => {
         clearOldData();
-    },[clearOldData])
+    }, [clearOldData])
 
     const Headings = {
         mainMenu: "DEMO MENU",
@@ -94,6 +94,7 @@ const useHeader = () => {
             case urls.subsidyListDone:
             case urls.subsidyVCList:
             case urls.subsidyVCListDetail:
+            case urls.subsidyVCListDone:
                 return colors.subsidy;
             default:
                 return "";
@@ -152,6 +153,7 @@ const useHeader = () => {
             case urls.subsidyListDone:
             case urls.subsidyVCList:
             case urls.subsidyVCListDetail:
+            case urls.subsidyVCListDone:
                 return Headings.subsidyMenu;
             default:
                 return "不正なURL";
@@ -208,6 +210,7 @@ const useHeader = () => {
             case urls.subsidyListDone:
             case urls.subsidyVCList:
             case urls.subsidyVCListDetail:
+            case urls.subsidyVCListDone:
                 return icons.subsidy;
             default:
                 return "";
@@ -265,6 +268,7 @@ const useHeader = () => {
             case urls.subsidyListDone:
             case urls.subsidyVCList:
             case urls.subsidyVCListDetail:
+            case urls.subsidyVCListDone:
                 return { url: urls.subsidyMenu, label: "menu" };
             default:
                 return { url: "", label: "" };
@@ -321,6 +325,7 @@ const useHeader = () => {
             case urls.subsidyListDone:
             case urls.subsidyVCList:
             case urls.subsidyVCListDetail:
+            case urls.subsidyVCListDone:
                 return Titles.subsidyMenu;
             default:
                 return "";

--- a/algo/firebase/front/src/components/common/PageTitle/usePageTitle.tsx
+++ b/algo/firebase/front/src/components/common/PageTitle/usePageTitle.tsx
@@ -99,6 +99,7 @@ const usePageTitle = () => {
             case urls.residentVCListDone:
             case urls.accountVCListDone:
             case urls.taxVCListDone:
+            case urls.subsidyVCListDone:
                 return title.VCRevoke;
         }
     }

--- a/algo/firebase/front/src/components/common/VCListContainer/useVCListContainer.tsx
+++ b/algo/firebase/front/src/components/common/VCListContainer/useVCListContainer.tsx
@@ -50,7 +50,6 @@ const useVCListContainer = () => {
 
     const onApply = (type: string) => {
         handleClearInputState();
-        console.log(type);
         
         switch (type) {
             case "住民票":

--- a/algo/firebase/front/src/components/common/VCRevokeDone/VCRevokeDone.tsx
+++ b/algo/firebase/front/src/components/common/VCRevokeDone/VCRevokeDone.tsx
@@ -15,6 +15,8 @@ const VCRevokeDone = () => {
                 return { msg: "銀行メニューへ", listUrl: urls.accountVCList, menuUrl: urls.accountMenu };
             case urls.taxVCListDone:
                 return { msg: "税務署メニューへ", listUrl: urls.taxVCList, menuUrl: urls.taxMenu };
+            case urls.subsidyVCListDone:
+                return { msg: "申請先メニューへ", listUrl: urls.subsidyVCList, menuUrl: urls.subsidyMenu };
             default:
                 return { msg: "", listUrl: "", menuUrl: "" };
         }

--- a/algo/firebase/front/src/components/common/VCSelect/Select.tsx
+++ b/algo/firebase/front/src/components/common/VCSelect/Select.tsx
@@ -39,7 +39,7 @@ const VCSelect = <T extends FieldValues>({ name, label, items, validation = unde
                         : <option></option>
                     }
                 </select>
-                <label htmlFor={name} className={"absolute left-0 top-1/2 translate-x-2 -translate-y-1/2"}>{!select ? label : null}</label>
+                <label htmlFor={name} className={"absolute left-0 top-1/2 translate-x-2 -translate-y-1/2"}>{!select ? `${label} - VC0` : null}</label>
                 <svg className={"absolute right-0 top-1/2 -translate-x-2 -translate-y-1/2"} width="21" height="10" viewBox="0 0 21 10" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M21 0L0.000143051 0L10.5001 10L21 0Z" fill="#00938A" />
                 </svg>

--- a/algo/firebase/front/src/components/util/useDataClear.tsx
+++ b/algo/firebase/front/src/components/util/useDataClear.tsx
@@ -80,9 +80,9 @@ const useDataClear = () => {
         }))
         clearSubsidyInputState(() => ({
             id: 0,
-            resident: "",
-            account: "",
-            tax: "",
+            residentVC: "",
+            accountVC: "",
+            taxVC: "",
             fullName: "",
             address: "",
             applicationDate: "",

--- a/algo/firebase/front/src/components/util/useDataClear.tsx
+++ b/algo/firebase/front/src/components/util/useDataClear.tsx
@@ -1,4 +1,4 @@
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import {
     residentInputState,
@@ -16,6 +16,7 @@ import {
 } from '@/lib/states/mockApp';
 import { useErrorHandler } from 'react-error-boundary';
 import { useState } from 'react';
+import { dataVerState } from '@/lib/states/mockApp/dataVersion';
 
 
 const useDataClear = () => {
@@ -30,7 +31,8 @@ const useDataClear = () => {
     const clearTaxVCRequestListState = useSetRecoilState(taxVCRequestListState);
     const clearSubsidyInputState = useSetRecoilState(subsidyInputState);
     const clearSubsidyListState = useSetRecoilState(subsidyListState);
-    const [VCList, clearVCListState] = useRecoilState(VCListState);
+    const clearVCListState = useSetRecoilState(VCListState);
+    const [dataVer,setDataVer] = useRecoilState(dataVerState);
 
     const [clearMsg, setclearMsg] = useState("")
 
@@ -119,16 +121,9 @@ const useDataClear = () => {
     };
 
     const clearOldData = () => {
-        if (VCList) {
-            if (VCList.resident && Array.isArray(VCList.resident) && VCList.resident.length > 0 && Object.hasOwn(VCList.resident[0], "acceptStatus")) {
-                clearAllState();
-            }
-            if (VCList.account && Array.isArray(VCList.account) && VCList.account.length > 0 && Object.hasOwn(VCList.account[0], "acceptStatus")) {
-                clearAllState();
-            }
-            if (VCList.tax && Array.isArray(VCList.tax) && VCList.tax.length > 0 && Object.hasOwn(VCList.tax[0], "acceptStatus")) {
-                clearAllState();
-            }
+        if(!dataVer || dataVer < 1){
+            clearAllState();
+            setDataVer(1);
         }
     }
 

--- a/algo/firebase/front/src/lib/states/mockApp/dataVersion.ts
+++ b/algo/firebase/front/src/lib/states/mockApp/dataVersion.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+import persistAtom from '../persistAtom';
+
+export const dataVerState = atom<number>({
+    key: 'dataVerState',
+    default: 0,
+    effects_UNSTABLE: [persistAtom],
+});

--- a/algo/firebase/front/src/lib/states/mockApp/subsidyInputState.ts
+++ b/algo/firebase/front/src/lib/states/mockApp/subsidyInputState.ts
@@ -7,9 +7,9 @@ export const subsidyInputState = atom<SubsidyInputFormType>({
     key: 'subsidyInputState',
     default: {
         id: 0,
-        resident: "0",
-        account: "0",
-        tax: "0",
+        residentVC: "0",
+        accountVC: "0",
+        taxVC: "0",
         fullName: "",
         address: "",
         applicationDate: "",

--- a/algo/firebase/front/src/lib/types/mockApp/Form.ts
+++ b/algo/firebase/front/src/lib/types/mockApp/Form.ts
@@ -33,9 +33,6 @@ export type SubsidyInputFormType = {
     residentVC: string;
     accountVC: string;
     taxVC: string;
-    residentVerifyStatus?: boolean;
-    accountVerifyStatus?: boolean;
-    taxVerifyStatus?: boolean;
     fullName: string;
     address: string;
     residentVP: VerifiableMessage<VPContent> | undefined;

--- a/algo/firebase/front/src/lib/types/mockApp/Form.ts
+++ b/algo/firebase/front/src/lib/types/mockApp/Form.ts
@@ -30,9 +30,9 @@ export type SubsidyVCType = VerifiableMessage<VerifiableCredentialContent<Subsid
 
 export type SubsidyInputFormType = {
     id: number;
-    resident: string;
-    account: string;
-    tax: string;
+    residentVC: string;
+    accountVC: string;
+    taxVC: string;
     residentVerifyStatus?: boolean;
     accountVerifyStatus?: boolean;
     taxVerifyStatus?: boolean;

--- a/algo/firebase/front/src/lib/types/mockApp/index.ts
+++ b/algo/firebase/front/src/lib/types/mockApp/index.ts
@@ -45,7 +45,8 @@ export const urls = {
     taxVCListDetail: "/102_taxVCListDetail",
     taxVCListDone: "/103_taxVCListDone",
     subsidyVCList: "/111_subsidyVCList",
-    subsidyVCListDetail: "/112_subsidyVCListDetail"
+    subsidyVCListDetail: "/112_subsidyVCListDetail",
+    subsidyVCListDone: "/113_subsidyVCListDone"
 } as const;
 
 export const icons = {

--- a/algo/firebase/front/src/pages/113_subsidyVCListDone.tsx
+++ b/algo/firebase/front/src/pages/113_subsidyVCListDone.tsx
@@ -1,0 +1,9 @@
+import SubsidyVCListDoneMain from '@/components/113_subsidyVCListDone';
+import type { NextPage } from 'next';
+
+
+const SubsidyVCListDone: NextPage = () => {
+    return <SubsidyVCListDoneMain />;
+};
+
+export default SubsidyVCListDone;


### PR DESCRIPTION
■プルリク内容
●15, 25, 35で承認済の左にチェックアイコンを表示
●自動データクリア改良
●35と15, 25のボタンの並びを合わせる
●102のVC取消中の位置修正
●45の承認ボタン押下時のメッセージを修正
●ヘッダーに戻るボタンを追加
●41で口座実在証明書と納税証明書VCが自動でセットされているときは、VC名を表示するように修正
●45検証を自動で行い、OKの場合承認ボタン、NGの場合却下ボタンを表示するように修正
●112に取消ボタンを追加